### PR TITLE
Add Onboarding feature

### DIFF
--- a/lib/features/onboarding/bindings.dart
+++ b/lib/features/onboarding/bindings.dart
@@ -1,0 +1,10 @@
+import 'package:get/get.dart';
+
+import 'presentation/controller/onboarding_controller.dart';
+
+class OnboardingBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => OnboardingController());
+  }
+}

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -1,0 +1,13 @@
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+
+class OnboardingController extends GetxController {
+  final box = GetStorage();
+  final pageIndex = 0.obs;
+
+  static const hasOnboardedKey = 'hasOnboarded';
+
+  void completeOnboarding() {
+    box.write(hasOnboardedKey, true);
+  }
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../routes.dart';
+import '../controller/onboarding_controller.dart';
+import '../widgets/slide_card.dart';
+import '../widgets/dots_indicator.dart';
+
+class OnboardingPage extends GetView<OnboardingController> {
+  OnboardingPage({super.key});
+
+  final _pageController = PageController();
+
+  final _slides = const [
+    (
+      'https://assets9.lottiefiles.com/packages/lf20_iwmd6pyr.json',
+      'Welcome',
+      'Discover new possibilities'
+    ),
+    (
+      'https://assets9.lottiefiles.com/packages/lf20_touohxv0.json',
+      'Learn',
+      'Build your skills quickly'
+    ),
+    (
+      'https://assets9.lottiefiles.com/packages/lf20_w51pcehl.json',
+      'Achieve',
+      'Reach your goals faster'
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  itemCount: _slides.length,
+                  onPageChanged: controller.pageIndex,
+                  itemBuilder: (context, index) {
+                    final slide = _slides[index];
+                    return SlideCard(
+                      animationUrl: slide.$1,
+                      title: slide.$2,
+                      subtitle: slide.$3,
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 24),
+              Obx(
+                () => DotsIndicator(
+                  controller: _pageController,
+                  count: _slides.length,
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+      floatingActionButton: Obx(
+        () => FloatingActionButton(
+          onPressed: () {
+            if (controller.pageIndex.value == _slides.length - 1) {
+              controller.completeOnboarding();
+              Get.offAllNamed(Routes.home);
+            } else {
+              _pageController.nextPage(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+              );
+            }
+          },
+          backgroundColor: colorScheme.primary,
+          child: const Icon(Icons.arrow_forward),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/dots_indicator.dart
+++ b/lib/features/onboarding/presentation/widgets/dots_indicator.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class DotsIndicator extends StatelessWidget {
+  const DotsIndicator({
+    super.key,
+    required this.controller,
+    required this.count,
+  });
+
+  final PageController controller;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return SmoothPageIndicator(
+      controller: controller,
+      count: count,
+      effect: WormEffect(
+        activeDotColor: Theme.of(context).colorScheme.primary,
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/slide_card.dart
+++ b/lib/features/onboarding/presentation/widgets/slide_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+
+class SlideCard extends StatelessWidget {
+  const SlideCard({
+    super.key,
+    required this.animationUrl,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final String animationUrl;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Expanded(
+          child: Lottie.network(animationUrl,
+              fit: BoxFit.contain, width: double.infinity),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          subtitle,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,0 +1,6 @@
+class Routes {
+  Routes._();
+
+  static const home = '/';
+  static const onboarding = '/onboarding';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,10 @@ dependencies:
   path_provider: ^2.1.2
   cached_network_image: ^3.3.0
 
+  # 🎠 UI helpers
+  smooth_page_indicator: ^1.1.0
+  lottie: ^3.0.0
+
   flutter_dotenv: ^5.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- implement onboarding presentation layer with slides
- add GetX controller and binding for onboarding
- add `Routes` constants for home and onboarding
- include UI helper widgets
- add `lottie` and `smooth_page_indicator` dependencies

## Testing
- `dart` command not found, so formatting and tests could not run


------
https://chatgpt.com/codex/tasks/task_e_687898a57cec8331a64d55f2c55381f0