### PR TITLE
Implement onboarding flow

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'features/onboarding/presentation/pages/onboarding_steps.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -11,7 +12,10 @@ class App extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Relaunch Programming'),
+      routes: {
+        '/': (context) => const MyHomePage(title: 'Relaunch Programming'),
+      },
+      home: const OnboardingStep1(),
     );
   }
 }

--- a/lib/features/onboarding/presentation/pages/onboarding_steps.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_steps.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import '../widgets/onboarding_screen.dart';
+
+class OnboardingStep1 extends StatelessWidget {
+  const OnboardingStep1({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return OnboardingScreen(
+      emoji: '🚴‍♀️',
+      title: 'Products from worldwide',
+      description:
+          'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      currentStep: 0,
+      totalSteps: 3,
+      onNext: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const OnboardingStep2()),
+        );
+      },
+      onSkip: () {
+        Navigator.pushReplacementNamed(context, '/');
+      },
+    );
+  }
+}
+
+class OnboardingStep2 extends StatelessWidget {
+  const OnboardingStep2({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return OnboardingScreen(
+      emoji: '🏃‍♀️',
+      title: 'Buy from anywhere',
+      description:
+          'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      currentStep: 1,
+      totalSteps: 3,
+      onNext: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const OnboardingStep3()),
+        );
+      },
+      onSkip: () {
+        Navigator.pushReplacementNamed(context, '/');
+      },
+    );
+  }
+}
+
+class OnboardingStep3 extends StatelessWidget {
+  const OnboardingStep3({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return OnboardingScreen(
+      emoji: '👥',
+      title: 'Join the community',
+      description:
+          'Get advice and inspiration from more than 1 million users and help each other out',
+      currentStep: 2,
+      totalSteps: 3,
+      onNext: () {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Welcome!'),
+            content: const Text('Onboarding complete!'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  Navigator.pushReplacementNamed(context, '/');
+                },
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
+        );
+      },
+      onSkip: () {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Welcome!'),
+            content: const Text('Onboarding complete!'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  Navigator.pushReplacementNamed(context, '/');
+                },
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
+        );
+      },
+      buttonLabel: 'Get Started',
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+class OnboardingScreen extends StatelessWidget {
+  const OnboardingScreen({
+    super.key,
+    required this.emoji,
+    required this.title,
+    required this.description,
+    required this.currentStep,
+    required this.totalSteps,
+    required this.onNext,
+    required this.onSkip,
+    this.buttonLabel = 'Next',
+  });
+
+  final String emoji;
+  final String title;
+  final String description;
+  final int currentStep;
+  final int totalSteps;
+  final VoidCallback onNext;
+  final VoidCallback onSkip;
+  final String buttonLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          TextButton(
+            onPressed: onSkip,
+            child: const Text('Skip'),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Spacer(),
+            Text(
+              emoji,
+              style: const TextStyle(fontSize: 64),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              description,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium,
+            ),
+            const Spacer(),
+            _StepsIndicator(currentStep: currentStep, totalSteps: totalSteps),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onNext,
+                child: Text(buttonLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StepsIndicator extends StatelessWidget {
+  const _StepsIndicator({required this.currentStep, required this.totalSteps});
+
+  final int currentStep;
+  final int totalSteps;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(totalSteps, (index) {
+        final isActive = index == currentStep;
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: isActive ? colorScheme.primary : colorScheme.outlineVariant,
+          ),
+        );
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `OnboardingScreen` widget
- create individual onboarding step pages using the widget
- start the app on `OnboardingStep1` and register home route

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789bdd295883318a380affaad2896a