### PR TITLE
Add GetX onboarding flow

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,21 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'features/onboarding/presentation/pages/onboarding_steps.dart';
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+
+import 'features/onboarding/bindings.dart';
+import 'features/onboarding/presentation/pages/onboarding_page.dart';
+import 'features/onboarding/presentation/controller/onboarding_controller.dart';
+import 'routes.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    final box = GetStorage();
+    final initialRoute =
+        box.read(OnboardingController.hasOnboardedKey) == true
+            ? AppRoutes.home
+            : AppRoutes.onboarding;
+    return GetMaterialApp(
       title: 'Relaunch Programming',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      routes: {
-        '/': (context) => const MyHomePage(title: 'Relaunch Programming'),
-      },
-      home: const OnboardingStep1(),
+      initialRoute: initialRoute,
+      getPages: [
+        GetPage(
+          name: AppRoutes.home,
+          page: () => const MyHomePage(title: 'Relaunch Programming'),
+        ),
+        GetPage(
+          name: AppRoutes.onboarding,
+          page: () => const OnboardingPage(),
+          binding: OnboardingBinding(),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -1,13 +1,47 @@
+import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 
+import '../../../routes.dart';
+
 class OnboardingController extends GetxController {
   final box = GetStorage();
-  final pageIndex = 0.obs;
+
+  final page = 0.obs;
+  final pageController = PageController();
 
   static const hasOnboardedKey = 'hasOnboarded';
 
-  void completeOnboarding() {
+  bool get hasOnboarded => box.read(hasOnboardedKey) ?? false;
+
+  @override
+  void onInit() {
+    super.onInit();
+    if (hasOnboarded) {
+      Future.microtask(() => Get.offAllNamed(AppRoutes.home));
+    }
+    pageController.addListener(() {
+      page.value = pageController.page?.round() ?? 0;
+    });
+  }
+
+  void next() {
+    if (page.value == 2) {
+      box.write(hasOnboardedKey, true);
+      Get.offAllNamed(AppRoutes.home);
+    } else {
+      pageController.nextPage(duration: 300.ms, curve: Curves.ease);
+    }
+  }
+
+  void back() {
+    if (page.value > 0) {
+      pageController.previousPage(duration: 300.ms, curve: Curves.ease);
+    }
+  }
+
+  void skip() {
     box.write(hasOnboardedKey, true);
+    Get.offAllNamed(AppRoutes.home);
   }
 }

--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:lottie/lottie.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class IntroPage extends GetView<OnboardingController> {
+  const IntroPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Lottie.network(
+              'https://assets9.lottiefiles.com/packages/lf20_iwmd6pyr.json',
+              fit: BoxFit.contain,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Welcome',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Discover new possibilities',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,85 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../routes.dart';
 import '../controller/onboarding_controller.dart';
-import '../widgets/slide_card.dart';
-import '../widgets/dots_indicator.dart';
+import '../widgets/progress_dots.dart';
+import 'intro_page.dart';
+import 'privacy_page.dart';
+import 'theme_choice_page.dart';
 
 class OnboardingPage extends GetView<OnboardingController> {
-  OnboardingPage({super.key});
+  const OnboardingPage({super.key});
 
-  final _pageController = PageController();
-
-  final _slides = const [
-    (
-      'https://assets9.lottiefiles.com/packages/lf20_iwmd6pyr.json',
-      'Welcome',
-      'Discover new possibilities'
-    ),
-    (
-      'https://assets9.lottiefiles.com/packages/lf20_touohxv0.json',
-      'Learn',
-      'Build your skills quickly'
-    ),
-    (
-      'https://assets9.lottiefiles.com/packages/lf20_w51pcehl.json',
-      'Achieve',
-      'Reach your goals faster'
-    ),
+  static final _pages = [
+    const IntroPage(),
+    const PrivacyPage(),
+    const ThemeChoicePage(),
   ];
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              Expanded(
-                child: PageView.builder(
-                  controller: _pageController,
-                  itemCount: _slides.length,
-                  onPageChanged: controller.pageIndex,
-                  itemBuilder: (context, index) {
-                    final slide = _slides[index];
-                    return SlideCard(
-                      animationUrl: slide.$1,
-                      title: slide.$2,
-                      subtitle: slide.$3,
-                    );
-                  },
-                ),
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: controller.pageController,
+                onPageChanged: (i) => controller.page.value = i,
+                children: _pages,
               ),
-              const SizedBox(height: 24),
-              Obx(
-                () => DotsIndicator(
-                  controller: _pageController,
-                  count: _slides.length,
-                ),
+            ),
+            const SizedBox(height: 24),
+            const ProgressDots(),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  TextButton(
+                    onPressed: controller.skip,
+                    child: const Text('Skip'),
+                  ),
+                  const Spacer(),
+                  Obx(
+                    () => Visibility(
+                      visible: controller.page.value > 0,
+                      child: TextButton(
+                        onPressed: controller.back,
+                        child: const Text('Back'),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Obx(
+                    () => ElevatedButton(
+                      onPressed: controller.next,
+                      child: Text(
+                        controller.page.value == _pages.length - 1
+                            ? 'Done'
+                            : 'Next',
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 24),
-            ],
-          ),
-        ),
-      ),
-      floatingActionButton: Obx(
-        () => FloatingActionButton(
-          onPressed: () {
-            if (controller.pageIndex.value == _slides.length - 1) {
-              controller.completeOnboarding();
-              Get.offAllNamed(Routes.home);
-            } else {
-              _pageController.nextPage(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeInOut,
-              );
-            }
-          },
-          backgroundColor: colorScheme.primary,
-          child: const Icon(Icons.arrow_forward),
+            ),
+            const SizedBox(height: 16),
+          ],
         ),
       ),
     );

--- a/lib/features/onboarding/presentation/pages/privacy_page.dart
+++ b/lib/features/onboarding/presentation/pages/privacy_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:lottie/lottie.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class PrivacyPage extends GetView<OnboardingController> {
+  const PrivacyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Lottie.network(
+              'https://assets9.lottiefiles.com/packages/lf20_touohxv0.json',
+              fit: BoxFit.contain,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Privacy',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'We respect your privacy',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:lottie/lottie.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class ThemeChoicePage extends GetView<OnboardingController> {
+  const ThemeChoicePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Lottie.network(
+              'https://assets9.lottiefiles.com/packages/lf20_w51pcehl.json',
+              fit: BoxFit.contain,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Choose a theme',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Pick the look that suits you',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/progress_dots.dart
+++ b/lib/features/onboarding/presentation/widgets/progress_dots.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class ProgressDots extends GetView<OnboardingController> {
+  const ProgressDots({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => AnimatedSmoothIndicator(
+        activeIndex: controller.page.value,
+        count: 3,
+        effect: WormEffect(
+          activeDotColor: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get_storage/get_storage.dart';
 import 'app.dart';
 
 Future<void> mainCommon(String envFile) async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: envFile);
+  await GetStorage.init();
   runApp(const App());
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,5 +1,5 @@
-class Routes {
-  Routes._();
+class AppRoutes {
+  AppRoutes._();
 
   static const home = '/';
   static const onboarding = '/onboarding';


### PR DESCRIPTION
## Summary
- implement new OnboardingController with GetX logic and GetStorage persistence
- create onboarding pages (intro, privacy, theme choice) with Lottie placeholders
- add progress dots widget
- rebuild OnboardingPage to host pages in a pager with skip/back/next
- switch to GetMaterialApp routing and init GetStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a79686988331a4654992deca5ece