### PR TITLE
Add bottom navigation shell

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,11 @@ import 'package:get_storage/get_storage.dart';
 import 'features/onboarding/bindings.dart';
 import 'features/onboarding/presentation/pages/onboarding_page.dart';
 import 'features/onboarding/presentation/controller/onboarding_controller.dart';
+import 'features/dashboard/dashboard_binding.dart';
+import 'features/dashboard/dashboard_page.dart';
+import 'features/home/home_page.dart';
+import 'features/settings/settings_page.dart';
+import 'features/profile/profile_page.dart';
 import 'routes.dart';
 
 class App extends StatelessWidget {
@@ -16,7 +21,7 @@ class App extends StatelessWidget {
     final box = GetStorage();
     final initialRoute =
         box.read(OnboardingController.hasOnboardedKey) == true
-            ? AppRoutes.home
+            ? AppRoutes.dashboard
             : AppRoutes.onboarding;
     return GetMaterialApp(
       debugShowCheckedModeBanner: false,
@@ -27,8 +32,21 @@ class App extends StatelessWidget {
       initialRoute: initialRoute,
       getPages: [
         GetPage(
+          name: AppRoutes.dashboard,
+          page: () => const DashboardPage(),
+          binding: DashboardBinding(),
+        ),
+        GetPage(
           name: AppRoutes.home,
-          page: () => const MyHomePage(title: 'Relaunch Programming'),
+          page: () => const HomePage(),
+        ),
+        GetPage(
+          name: AppRoutes.settings,
+          page: () => const SettingsPage(),
+        ),
+        GetPage(
+          name: AppRoutes.profile,
+          page: () => const ProfilePage(),
         ),
         GetPage(
           name: AppRoutes.onboarding,

--- a/lib/features/dashboard/dashboard_binding.dart
+++ b/lib/features/dashboard/dashboard_binding.dart
@@ -1,0 +1,10 @@
+import 'package:get/get.dart';
+
+import 'dashboard_controller.dart';
+
+class DashboardBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => DashboardController());
+  }
+}

--- a/lib/features/dashboard/dashboard_controller.dart
+++ b/lib/features/dashboard/dashboard_controller.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+
+class DashboardController extends GetxController {
+  final currentIndex = 0.obs;
+
+  void changeIndex(int index) {
+    currentIndex.value = index;
+  }
+}

--- a/lib/features/dashboard/dashboard_page.dart
+++ b/lib/features/dashboard/dashboard_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'dashboard_controller.dart';
+import '../home/home_page.dart';
+import '../settings/settings_page.dart';
+import '../profile/profile_page.dart';
+
+class DashboardPage extends GetView<DashboardController> {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = const [HomePage(), SettingsPage(), ProfilePage()];
+
+    return Obx(
+      () => Scaffold(
+        body: IndexedStack(
+          index: controller.currentIndex.value,
+          children: pages,
+        ),
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: controller.currentIndex.value,
+          onTap: controller.changeIndex,
+          items: const [
+            BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+            BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+            BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('Home Page'));
+  }
+}

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -17,7 +17,7 @@ class OnboardingController extends GetxController {
   void onInit() {
     super.onInit();
     if (hasOnboarded) {
-      Future.microtask(() => Get.offAllNamed(AppRoutes.home));
+      Future.microtask(() => Get.offAllNamed(AppRoutes.dashboard));
     }
     pageController.addListener(() {
       page.value = pageController.page?.round() ?? 0;
@@ -27,7 +27,7 @@ class OnboardingController extends GetxController {
   void next() {
     if (page.value == 2) {
       box.write(hasOnboardedKey, true);
-      Get.offAllNamed(AppRoutes.home);
+      Get.offAllNamed(AppRoutes.dashboard);
     } else {
       pageController.nextPage(duration: 300.milliseconds, curve: Curves.ease);
     }
@@ -41,6 +41,6 @@ class OnboardingController extends GetxController {
 
   void skip() {
     box.write(hasOnboardedKey, true);
-    Get.offAllNamed(AppRoutes.home);
+    Get.offAllNamed(AppRoutes.dashboard);
   }
 }

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('Profile Page'));
+  }
+}

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('Settings Page'));
+  }
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,6 +1,9 @@
 class AppRoutes {
   AppRoutes._();
 
-  static const home = '/';
+  static const dashboard = '/';
+  static const home = '/home';
+  static const settings = '/settings';
+  static const profile = '/profile';
   static const onboarding = '/onboarding';
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,38 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:relaunch_programming/app.dart';
-
+import 'package:get/get.dart';
+import 'package:relaunch_programming/features/dashboard/dashboard_binding.dart';
+import 'package:relaunch_programming/features/dashboard/dashboard_controller.dart';
+import 'package:relaunch_programming/features/dashboard/dashboard_page.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const App());
+  testWidgets('Dashboard bottom navigation works', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      GetMaterialApp(
+        home: const DashboardPage(),
+        initialBinding: DashboardBinding(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Profile'), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    final controller = Get.find<DashboardController>();
+    expect(controller.currentIndex.value, 0);
+    expect(find.text('Home Page'), findsOneWidget);
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+
+    expect(controller.currentIndex.value, 1);
+    expect(find.text('Settings Page'), findsOneWidget);
+
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+
+    expect(controller.currentIndex.value, 2);
+    expect(find.text('Profile Page'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement persistent Dashboard navigation with GetX
- add placeholder Home, Settings, and Profile pages
- update App routes and onboarding logic to use Dashboard
- create Dashboard controller, binding, and view
- add widget tests for bottom navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f6f8e44483319819ec11fd18336b