### PR TITLE
Add Python learning module

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "org.mihir.relaunch"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 21
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
@@ -59,4 +59,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation("com.github.python-ffi:python_ffi_android:0.2.0")
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+# Define minimum iOS version
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -31,6 +31,7 @@ target 'Runner' do
   use_frameworks!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  pod 'python_ffi_ios', :path => File.join('..', '.symlinks', 'plugins', 'python_ffi_ios', 'ios')
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,9 @@ import 'features/dashboard/dashboard_page.dart';
 import 'features/home/home_page.dart';
 import 'features/settings/settings_page.dart';
 import 'features/profile/profile_page.dart';
+import 'features/python_learning/bindings.dart';
+import 'features/python_learning/presentation/pages/lesson_list_page.dart';
+import 'features/python_learning/presentation/pages/lesson_detail_page.dart';
 import 'routes.dart';
 
 class App extends StatelessWidget {
@@ -52,6 +55,15 @@ class App extends StatelessWidget {
           name: AppRoutes.onboarding,
           page: () => const OnboardingPage(),
           binding: OnboardingBinding(),
+        ),
+        GetPage(
+          name: AppRoutes.pythonLearning,
+          page: () => const LessonListPage(),
+          binding: PythonLearningBinding(),
+        ),
+        GetPage(
+          name: AppRoutes.pythonLearningDetail,
+          page: () => const LessonDetailPage(),
         ),
       ],
     );

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../routes.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Home Page'));
+    return ListView(
+      children: [
+        ListTile(
+          title: const Text('Python Learning Module'),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => Get.toNamed(AppRoutes.pythonLearning),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/python_learning/bindings.dart
+++ b/lib/features/python_learning/bindings.dart
@@ -1,0 +1,25 @@
+import 'package:get/get.dart';
+
+import 'data/repositories/lesson_repository.dart';
+import 'domain/usecases/get_lessons_usecase.dart';
+import 'domain/usecases/execute_python_code_usecase.dart';
+import 'domain/usecases/save_progress_usecase.dart';
+import 'domain/usecases/get_progress_usecase.dart';
+import 'presentation/controller/python_learning_controller.dart';
+
+class PythonLearningBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => LessonRepository());
+    Get.lazyPut(() => GetLessonsUseCase(Get.find()));
+    Get.lazyPut(() => ExecutePythonCodeUseCase());
+    Get.lazyPut(() => SaveProgressUseCase());
+    Get.lazyPut(() => GetProgressUseCase());
+    Get.lazyPut(() => PythonLearningController(
+          getLessons: Get.find(),
+          executeCode: Get.find(),
+          saveProgress: Get.find(),
+          getProgress: Get.find(),
+        ));
+  }
+}

--- a/lib/features/python_learning/data/models/lesson.dart
+++ b/lib/features/python_learning/data/models/lesson.dart
@@ -1,0 +1,36 @@
+import '../../domain/entities/lesson_entity.dart';
+
+class Lesson extends LessonEntity {
+  Lesson({
+    required super.id,
+    required super.title,
+    required super.description,
+    required super.initialCode,
+    required super.testCases,
+    super.isCompleted = false,
+  });
+
+  factory Lesson.fromJson(Map<String, dynamic> json) {
+    final testCases = (json['testCases'] as List?)
+            ?.map((e) => Map<String, String>.from(e as Map))
+            .toList() ??
+        [];
+    return Lesson(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      initialCode: json['initialCode'] as String,
+      testCases: testCases,
+      isCompleted: json['isCompleted'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'initialCode': initialCode,
+        'testCases': testCases,
+        'isCompleted': isCompleted,
+      };
+}

--- a/lib/features/python_learning/data/repositories/lesson_repository.dart
+++ b/lib/features/python_learning/data/repositories/lesson_repository.dart
@@ -1,0 +1,37 @@
+import '../models/lesson.dart';
+
+class LessonRepository {
+  Future<List<Lesson>> getLessons() async {
+    return _lessons;
+  }
+
+  final List<Lesson> _lessons = [
+    Lesson(
+      id: '1',
+      title: 'Hello World',
+      description: 'Print "Hello World" to the console.',
+      initialCode: "print('Hello World')",
+      testCases: [
+        {'input': '', 'expectedOutput': 'Hello World\n'},
+      ],
+    ),
+    Lesson(
+      id: '2',
+      title: 'Variables and Data Types',
+      description: 'Create a variable called x with value 5 and print it.',
+      initialCode: 'x = 5\nprint(x)',
+      testCases: [
+        {'input': '', 'expectedOutput': '5\n'},
+      ],
+    ),
+    Lesson(
+      id: '3',
+      title: 'Functions',
+      description: 'Write a function add(a, b) that returns the sum.',
+      initialCode: 'def add(a, b):\n    return a + b',
+      testCases: [
+        {'input': 'add(2, 3)', 'expectedOutput': '5'},
+      ],
+    ),
+  ];
+}

--- a/lib/features/python_learning/domain/entities/lesson_entity.dart
+++ b/lib/features/python_learning/domain/entities/lesson_entity.dart
@@ -1,0 +1,17 @@
+class LessonEntity {
+  final String id;
+  final String title;
+  final String description;
+  final String initialCode;
+  final List<Map<String, String>> testCases;
+  bool isCompleted;
+
+  LessonEntity({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.initialCode,
+    required this.testCases,
+    this.isCompleted = false,
+  });
+}

--- a/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:python_ffi/python_ffi.dart';
+
+class PythonExecutionResult {
+  final String output;
+  final String error;
+  PythonExecutionResult({required this.output, required this.error});
+}
+
+class ExecutePythonCodeUseCase {
+  Future<PythonExecutionResult> call(String code) async {
+    try {
+      final builtins = PythonFfi.instance.importModule('builtins');
+      builtins.call('exec', <Object?>[code]);
+      final out = PythonFfi.instance.stdout.toString();
+      final err = PythonFfi.instance.stderr.toString();
+      return PythonExecutionResult(output: out, error: err);
+    } catch (e) {
+      return PythonExecutionResult(output: '', error: e.toString());
+    }
+  }
+}

--- a/lib/features/python_learning/domain/usecases/get_lessons_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/get_lessons_usecase.dart
@@ -1,0 +1,11 @@
+import '../../data/repositories/lesson_repository.dart';
+import '../entities/lesson_entity.dart';
+
+class GetLessonsUseCase {
+  final LessonRepository repository;
+  GetLessonsUseCase(this.repository);
+
+  Future<List<LessonEntity>> call() async {
+    return repository.getLessons();
+  }
+}

--- a/lib/features/python_learning/domain/usecases/get_progress_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/get_progress_usecase.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class GetProgressUseCase {
+  Future<Map<String, bool>> call() async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('python_learning_progress');
+    if (str == null) return {};
+    final Map<String, dynamic> json = jsonDecode(str);
+    return json.map((key, value) => MapEntry(key, value as bool));
+  }
+}

--- a/lib/features/python_learning/domain/usecases/save_progress_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/save_progress_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'dart:convert';
+
+class SaveProgressUseCase {
+  Future<void> call(Map<String, bool> progress) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'python_learning_progress',
+      jsonEncode(progress),
+    );
+  }
+}

--- a/lib/features/python_learning/presentation/controller/python_learning_controller.dart
+++ b/lib/features/python_learning/presentation/controller/python_learning_controller.dart
@@ -1,0 +1,73 @@
+import 'package:get/get.dart';
+
+import '../../domain/entities/lesson_entity.dart';
+import '../../domain/usecases/execute_python_code_usecase.dart';
+import '../../domain/usecases/get_lessons_usecase.dart';
+import '../../domain/usecases/save_progress_usecase.dart';
+import '../../domain/usecases/get_progress_usecase.dart';
+
+class PythonLearningController extends GetxController {
+  PythonLearningController({
+    required this.getLessons,
+    required this.executeCode,
+    required this.saveProgress,
+    required this.getProgress,
+  });
+
+  final GetLessonsUseCase getLessons;
+  final ExecutePythonCodeUseCase executeCode;
+  final SaveProgressUseCase saveProgress;
+  final GetProgressUseCase getProgress;
+
+  final lessons = <LessonEntity>[].obs;
+  final output = ''.obs;
+  final selectedIndex = 0.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadLessons();
+  }
+
+  Future<void> loadLessons() async {
+    final data = await getLessons();
+    final progress = await getProgress();
+    for (final lesson in data) {
+      lesson.isCompleted = progress[lesson.id] ?? false;
+    }
+    lessons.assignAll(data);
+  }
+
+  LessonEntity get currentLesson => lessons[selectedIndex.value];
+
+  Future<void> runCode(String code) async {
+    final result = await executeCode(code);
+    output.value = result.error.isNotEmpty ? result.error : result.output;
+  }
+
+  void checkAnswer(String code) {
+    final lesson = currentLesson;
+    final expected = lesson.testCases.first['expectedOutput'] ?? '';
+    if (output.value.trim() == expected.trim()) {
+      lesson.isCompleted = true;
+      updateLessonProgress();
+    }
+  }
+
+  Future<void> updateLessonProgress() async {
+    final progress = {for (var l in lessons) l.id: l.isCompleted};
+    await saveProgress(progress);
+  }
+
+  void nextLesson() {
+    if (selectedIndex.value < lessons.length - 1) {
+      selectedIndex.value += 1;
+    }
+  }
+
+  void previousLesson() {
+    if (selectedIndex.value > 0) {
+      selectedIndex.value -= 1;
+    }
+  }
+}

--- a/lib/features/python_learning/presentation/pages/lesson_detail_page.dart
+++ b/lib/features/python_learning/presentation/pages/lesson_detail_page.dart
@@ -1,0 +1,69 @@
+import 'package:code_text_field/code_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:highlight/languages/python.dart';
+
+import '../controller/python_learning_controller.dart';
+import '../widgets/code_editor_widget.dart';
+
+class LessonDetailPage extends StatefulWidget {
+  const LessonDetailPage({super.key});
+
+  @override
+  State<LessonDetailPage> createState() => _LessonDetailPageState();
+}
+
+class _LessonDetailPageState extends State<LessonDetailPage> {
+  late CodeController codeController;
+
+  @override
+  void initState() {
+    super.initState();
+    final lesson = Get.find<PythonLearningController>().currentLesson;
+    codeController = CodeController(
+      text: lesson.initialCode,
+      language: python,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<PythonLearningController>();
+    final lesson = controller.currentLesson;
+    return Scaffold(
+      appBar: AppBar(title: Text(lesson.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Text(lesson.description),
+            const SizedBox(height: 16),
+            Expanded(child: CodeEditorWidget(controller: codeController)),
+            const SizedBox(height: 16),
+            Obx(() => Text(controller.output.value)),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(
+                  onPressed: controller.previousLesson,
+                  child: const Text('Previous'),
+                ),
+                ElevatedButton(
+                  onPressed: controller.nextLesson,
+                  child: const Text('Next'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await controller.runCode(codeController.text);
+          controller.checkAnswer(codeController.text);
+        },
+        child: const Icon(Icons.play_arrow),
+      ),
+    );
+  }
+}

--- a/lib/features/python_learning/presentation/pages/lesson_list_page.dart
+++ b/lib/features/python_learning/presentation/pages/lesson_list_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controller/python_learning_controller.dart';
+import '../widgets/lesson_card.dart';
+import '../../routes.dart';
+
+class LessonListPage extends GetView<PythonLearningController> {
+  const LessonListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Python Lessons')),
+      body: Obx(
+        () => ListView.builder(
+          itemCount: controller.lessons.length,
+          itemBuilder: (context, index) {
+            final lesson = controller.lessons[index];
+            return LessonCard(
+              lesson: lesson,
+              onTap: () {
+                controller.selectedIndex.value = index;
+                Get.toNamed(PythonLearningRoutes.detail);
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
+++ b/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:code_text_field/code_text_field.dart';
+import 'package:flutter_highlight/themes/github.dart';
+import 'package:highlight/languages/python.dart';
+
+class CodeEditorWidget extends StatelessWidget {
+  final CodeController controller;
+  const CodeEditorWidget({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return CodeField(
+      controller: controller,
+      language: python,
+      textStyle: const TextStyle(fontFamily: 'monospace'),
+      theme: githubTheme,
+    );
+  }
+}

--- a/lib/features/python_learning/presentation/widgets/lesson_card.dart
+++ b/lib/features/python_learning/presentation/widgets/lesson_card.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/lesson_entity.dart';
+
+class LessonCard extends StatelessWidget {
+  final LessonEntity lesson;
+  final VoidCallback onTap;
+  const LessonCard({super.key, required this.lesson, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(lesson.title),
+        trailing: lesson.isCompleted
+            ? const Icon(Icons.check, color: Colors.green)
+            : const Icon(Icons.play_arrow),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/features/python_learning/routes.dart
+++ b/lib/features/python_learning/routes.dart
@@ -1,0 +1,6 @@
+class PythonLearningRoutes {
+  PythonLearningRoutes._();
+
+  static const list = '/python-learning';
+  static const detail = '/python-learning/detail';
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -6,4 +6,6 @@ class AppRoutes {
   static const settings = '/settings';
   static const profile = '/profile';
   static const onboarding = '/onboarding';
+  static const pythonLearning = '/python-learning';
+  static const pythonLearningDetail = '/python-learning/detail';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,12 @@ dependencies:
 
   flutter_dotenv: ^5.1.0
 
+  # 🐍 python learning module deps
+  python_ffi: ^0.2.0
+  shared_preferences: ^2.2.2
+  flutter_highlight: ^0.7.0
+  code_text_field: ^1.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/python_learning/domain/usecases/execute_python_code_usecase_test.dart
+++ b/test/features/python_learning/domain/usecases/execute_python_code_usecase_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:python_ffi/python_ffi.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/execute_python_code_usecase.dart';
+
+class MockPythonFfi extends Mock implements PythonFfi {}
+
+void main() {
+  test('ExecutePythonCodeUseCase captures output', () async {
+    final mock = MockPythonFfi();
+    PythonFfi.instance = mock;
+    when(() => mock.importModule('builtins')).thenReturn(MockPythonModule());
+    when(() => mock.stdout).thenReturn('out');
+    when(() => mock.stderr).thenReturn('');
+    final usecase = ExecutePythonCodeUseCase();
+    final result = await usecase('print(1)');
+    expect(result.output, 'out');
+  });
+}
+
+class MockPythonModule extends Mock implements PythonFfiModule {}

--- a/test/features/python_learning/domain/usecases/get_lessons_usecase_test.dart
+++ b/test/features/python_learning/domain/usecases/get_lessons_usecase_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_lessons_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/data/repositories/lesson_repository.dart';
+
+void main() {
+  test('GetLessonsUseCase returns lessons', () async {
+    final usecase = GetLessonsUseCase(LessonRepository());
+    final lessons = await usecase();
+    expect(lessons.isNotEmpty, true);
+  });
+}

--- a/test/features/python_learning/presentation/controller/python_learning_controller_test.dart
+++ b/test/features/python_learning/presentation/controller/python_learning_controller_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:relaunch_programming/features/python_learning/presentation/controller/python_learning_controller.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_lessons_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/execute_python_code_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/save_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/data/repositories/lesson_repository.dart';
+
+void main() {
+  test('Controller loads lessons', () async {
+    final controller = PythonLearningController(
+      getLessons: GetLessonsUseCase(LessonRepository()),
+      executeCode: ExecutePythonCodeUseCase(),
+      saveProgress: SaveProgressUseCase(),
+      getProgress: GetProgressUseCase(),
+    );
+    await controller.loadLessons();
+    expect(controller.lessons.isNotEmpty, true);
+  });
+}

--- a/test/features/python_learning/presentation/pages/lesson_detail_page_test.dart
+++ b/test/features/python_learning/presentation/pages/lesson_detail_page_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:relaunch_programming/features/python_learning/presentation/pages/lesson_detail_page.dart';
+import 'package:relaunch_programming/features/python_learning/presentation/controller/python_learning_controller.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_lessons_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/execute_python_code_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/save_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/data/repositories/lesson_repository.dart';
+
+void main() {
+  testWidgets('LessonDetailPage renders editor', (tester) async {
+    final controller = PythonLearningController(
+      getLessons: GetLessonsUseCase(LessonRepository()),
+      executeCode: ExecutePythonCodeUseCase(),
+      saveProgress: SaveProgressUseCase(),
+      getProgress: GetProgressUseCase(),
+    );
+    await controller.loadLessons();
+    Get.put(controller);
+    await tester.pumpWidget(const GetMaterialApp(home: LessonDetailPage()));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsWidgets);
+  });
+}

--- a/test/features/python_learning/presentation/pages/lesson_list_page_test.dart
+++ b/test/features/python_learning/presentation/pages/lesson_list_page_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:relaunch_programming/features/python_learning/presentation/pages/lesson_list_page.dart';
+import 'package:relaunch_programming/features/python_learning/presentation/controller/python_learning_controller.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_lessons_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/execute_python_code_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/save_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/domain/usecases/get_progress_usecase.dart';
+import 'package:relaunch_programming/features/python_learning/data/repositories/lesson_repository.dart';
+
+void main() {
+  testWidgets('LessonListPage shows lessons', (tester) async {
+    Get.put(PythonLearningController(
+      getLessons: GetLessonsUseCase(LessonRepository()),
+      executeCode: ExecutePythonCodeUseCase(),
+      saveProgress: SaveProgressUseCase(),
+      getProgress: GetProgressUseCase(),
+    ));
+    await tester.pumpWidget(const GetMaterialApp(home: LessonListPage()));
+    await tester.pumpAndSettle();
+    expect(find.byType(ListTile), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- integrate python learning module routes
- add lesson repository and domain logic
- add python FFI setup for Android/iOS
- create interactive lesson pages and widgets
- provide unit and widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fdef379c83318e6053571abf74e9