### PR TITLE
Fix python_ffi execution usecase

### DIFF
--- a/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:python_ffi/python_ffi.dart';
 
 class PythonExecutionResult {
@@ -6,14 +8,44 @@ class PythonExecutionResult {
   PythonExecutionResult({required this.output, required this.error});
 }
 
+class BuiltinsModule extends PythonModule {
+  BuiltinsModule.from(super.moduleDelegate) : super.from();
+
+  PythonFunction get _execFunc => getFunction('exec');
+
+  void exec(String code) => _execFunc.call(<Object?>[code]);
+
+  String get capturedOut => getAttribute<String>('__out');
+
+  String get capturedErr => getAttribute<String>('__err');
+}
+
 class ExecutePythonCodeUseCase {
   Future<PythonExecutionResult> call(String code) async {
     try {
-      final builtins = PythonFfi.instance.importModule('builtins');
-      builtins.call('exec', <Object?>[code]);
-      final out = PythonFfi.instance.stdout.toString();
-      final err = PythonFfi.instance.stderr.toString();
-      return PythonExecutionResult(output: out, error: err);
+      final builtins = PythonFfi.instance.importModule(
+        'builtins',
+        BuiltinsModule.from,
+      );
+
+      final escaped = jsonEncode(code);
+
+      final captureScript = '''
+import io, contextlib, builtins
+_stdout = io.StringIO()
+_stderr = io.StringIO()
+with contextlib.redirect_stdout(_stdout), contextlib.redirect_stderr(_stderr):
+    exec($escaped)
+builtins.__out = _stdout.getvalue()
+builtins.__err = _stderr.getvalue()
+''';
+
+      builtins.exec(captureScript);
+
+      return PythonExecutionResult(
+        output: builtins.capturedOut,
+        error: builtins.capturedErr,
+      );
     } catch (e) {
       return PythonExecutionResult(output: '', error: e.toString());
     }

--- a/test/features/python_learning/domain/usecases/execute_python_code_usecase_test.dart
+++ b/test/features/python_learning/domain/usecases/execute_python_code_usecase_test.dart
@@ -4,18 +4,26 @@ import 'package:python_ffi/python_ffi.dart';
 import 'package:relaunch_programming/features/python_learning/domain/usecases/execute_python_code_usecase.dart';
 
 class MockPythonFfi extends Mock implements PythonFfi {}
+class MockPythonModule extends Mock implements PythonModule {}
+class MockPythonFunction extends Mock implements PythonFunction {}
 
 void main() {
   test('ExecutePythonCodeUseCase captures output', () async {
-    final mock = MockPythonFfi();
-    PythonFfi.instance = mock;
-    when(() => mock.importModule('builtins')).thenReturn(MockPythonModule());
-    when(() => mock.stdout).thenReturn('out');
-    when(() => mock.stderr).thenReturn('');
+    final ffi = MockPythonFfi();
+    final module = MockPythonModule();
+    final func = MockPythonFunction();
+
+    PythonFfi.instance = ffi;
+
+    when(() => ffi.importModule('builtins', any())).thenReturn(module);
+    when(() => module.getFunction('exec')).thenReturn(func);
+    when(() => func.call(any())).thenReturn(null);
+    when(() => module.getAttribute<String>('__out')).thenReturn('out');
+    when(() => module.getAttribute<String>('__err')).thenReturn('');
+
     final usecase = ExecutePythonCodeUseCase();
     final result = await usecase('print(1)');
+
     expect(result.output, 'out');
   });
 }
-
-class MockPythonModule extends Mock implements PythonFfiModule {}


### PR DESCRIPTION
## Summary
- adjust `ExecutePythonCodeUseCase` for latest python_ffi API
- update tests to work with new module/function mocks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879008c50e883318dad16bd916e067e