### PR TITLE
Fix CodeField theme usage

### DIFF
--- a/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
+++ b/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
@@ -9,11 +9,13 @@ class CodeEditorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CodeField(
-      controller: controller,
-      language: python,
-      textStyle: const TextStyle(fontFamily: 'monospace'),
-      theme: githubTheme,
+    return CodeTheme(
+      data: const CodeThemeData(styles: githubTheme),
+      child: CodeField(
+        controller: controller,
+        language: python,
+        textStyle: const TextStyle(fontFamily: 'monospace'),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap CodeField in CodeTheme to apply github theme

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879018fbc4c83319fec0985afbc7db6