### PR TITLE
Fix Python code exec and editor widget

### DIFF
--- a/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
@@ -11,7 +11,7 @@ class PythonExecutionResult {
 class BuiltinsModule extends PythonModule {
   BuiltinsModule.from(super.moduleDelegate) : super.from();
 
-  PythonFunction get _execFunc => getFunction('exec');
+  PythonFunction get _execFunc => PythonFunction.from(getFunction('exec'));
 
   void exec(String code) => _execFunc.call(<Object?>[code]);
 

--- a/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
+++ b/lib/features/python_learning/presentation/widgets/code_editor_widget.dart
@@ -13,7 +13,6 @@ class CodeEditorWidget extends StatelessWidget {
       data: const CodeThemeData(styles: githubTheme),
       child: CodeField(
         controller: controller,
-        language: python,
         textStyle: const TextStyle(fontFamily: 'monospace'),
       ),
     );


### PR DESCRIPTION
## Summary
- fix PythonFunction return type for execute python code use case
- remove unsupported `language` parameter in code editor widget

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687903c6b5508331834f7ec41a472e88