### PR TITLE
Fix subclass of base PythonModule

### DIFF
--- a/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
+++ b/lib/features/python_learning/domain/usecases/execute_python_code_usecase.dart
@@ -8,7 +8,7 @@ class PythonExecutionResult {
   PythonExecutionResult({required this.output, required this.error});
 }
 
-class BuiltinsModule extends PythonModule {
+final class BuiltinsModule extends PythonModule {
   BuiltinsModule.from(super.moduleDelegate) : super.from();
 
   PythonFunction get _execFunc => PythonFunction.from(getFunction('exec'));


### PR DESCRIPTION
## Summary
- mark `BuiltinsModule` as `final` to comply with Dart's base-class rules

## Testing
- `apt-get update` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6879069cf21083318f2a46ce869b03f2