### PR TITLE
Fix layout for code execution controls

### DIFF
--- a/lib/features/python_learning/presentation/pages/lesson_detail_page.dart
+++ b/lib/features/python_learning/presentation/pages/lesson_detail_page.dart
@@ -41,22 +41,26 @@ class _LessonDetailPageState extends State<LessonDetailPage> {
             Expanded(child: CodeEditorWidget(controller: codeController)),
             const SizedBox(height: 16),
             Obx(() => Text(controller.output.value)),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                ElevatedButton(
-                  onPressed: controller.previousLesson,
-                  child: const Text('Previous'),
-                ),
-                ElevatedButton(
-                  onPressed: controller.nextLesson,
-                  child: const Text('Next'),
-                ),
-              ],
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ElevatedButton(
+              onPressed: controller.previousLesson,
+              child: const Text('Previous'),
+            ),
+            ElevatedButton(
+              onPressed: controller.nextLesson,
+              child: const Text('Next'),
             ),
           ],
         ),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           await controller.runCode(codeController.text);


### PR DESCRIPTION
## Summary
- adjust lesson detail page layout so the run code FAB doesn't overlap navigation buttons

## Testing
- `git show -n 1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68790b26d1fc8331a8a3e9af225d45a0