### PR TITLE
Fix Python FFI initialization

### DIFF
--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_storage/get_storage.dart';
+import 'package:python_ffi/python_ffi.dart';
 import 'app.dart';
 
 Future<void> mainCommon(String envFile) async {
   WidgetsFlutterBinding.ensureInitialized();
+  await PythonFfi.instance.initialize();
   await dotenv.load(fileName: envFile);
   await GetStorage.init();
   runApp(const App());


### PR DESCRIPTION
## Summary
- initialize `python_ffi` during startup

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790ef1817c8331adfc60d2b8a9e4d0